### PR TITLE
readmeを読み込む際にテキストエンコーディングを指定

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Windows環境でのインストール時に、デフォルトではutf-8が使われないためエラーが出てしまうのを修正